### PR TITLE
Add option to upload local image file to Samsung Frame TV

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+samsungtvws
+pillow
+requests


### PR DESCRIPTION
## Summary
- allow specifying `--image` to upload a local file instead of a Bing wallpaper
- require providing `--bingwallpaper` or `--image` and a `--tvip` address
- add `requirements.txt` to document dependencies (`pillow`, `requests`, `samsungtvws`)

## Testing
- `python -m py_compile frame_art_uploader.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement samsungtvws)*
- `pip install pillow requests` *(fails: Could not find a version that satisfies the requirement pillow)*
