### PR TITLE
Add Unsplash image source option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1>Frame Art Uploader 🖼️📺</h1>
-<p>Last opp kunst/bilder til <strong>Samsung The Frame</strong> via kommandolinjen. Støtter enten en lokal bildefil eller et tilfeldig <em>Bing Wallpaper</em>. Skriptet beskjærer/tilpasser automatisk til 3840×2160 (4K) før opplasting, og husker tidligere opplastede bilder i <code>uploaded_files.json</code>.</p>
+<p>Last opp kunst/bilder til <strong>Samsung The Frame</strong> via kommandolinjen. Støtter enten en lokal bildefil, et tilfeldig <em>Bing Wallpaper</em>, eller et tilfeldig landskapsbilde fra <em>Unsplash</em>. Skriptet beskjærer/tilpasser automatisk til 3840×2160 (4K) før opplasting, og husker tidligere opplastede bilder i <code>uploaded_files.json</code>.</p>
 
 <hr>
 
@@ -8,6 +8,7 @@
   <li>Python 3.9+</li>
   <li>TV og maskin på samme nettverk</li>
   <li>TV-en må støtte og (helst) være i <em>Art Mode</em></li>
+  <li>Unsplash API access key (kun hvis du bruker <code>--unsplash</code>)</li>
 </ul>
 
 <h2>📦 Installering</h2>
@@ -22,7 +23,9 @@ pip install -r requirements.txt
 <hr>
 
 <h2>▶️ Bruk</h2>
-<p>Kjør skriptet med <code>--tvip</code> og <em>én</em> av kildene <code>--bingwallpaper</code> eller <code>--image &lt;sti&gt;</code>.</p>
+<p>Kjør skriptet med <code>--tvip</code> og <em>én</em> av kildene <code>--bingwallpaper</code>, <code>--unsplash</code> eller <code>--image &lt;sti&gt;</code>.</p>
+
+<p>For <code>--unsplash</code> trenger du en <em>Unsplash API access key</em>. Sett den i miljøvariabelen <code>UNSPLASH_ACCESS_KEY</code> eller direkte i <code>frame_art_uploader.py</code>.</p>
 
 <h3>Eksempler</h3>
 <pre><code><h3>1) Bruk et tilfeldig Bing-bakgrunnsbilde på én TV</h3>
@@ -31,10 +34,15 @@ python3 frame_art_uploader.py --tvip 192.168.1.20 --bingwallpaper
 <h3>2) Last opp en lokal bildefil</h3>
 python3 frame_art_uploader.py --tvip 192.168.1.20 --image /path/til/bilde.jpg
 
-<h3>3) Flere TV-er (kommaseparert liste)</h3>
+<h3>3) Bruk et tilfeldig Unsplash-landsbilde</h3>
+# forutsetter at UNSPLASH_ACCESS_KEY er satt
+export UNSPLASH_ACCESS_KEY=din_nokkel
+python3 frame_art_uploader.py --tvip 192.168.1.20 --unsplash
+
+<h3>4) Flere TV-er (kommaseparert liste)</h3>
 python3 frame_art_uploader.py --tvip 192.168.1.20,192.168.1.21 --bingwallpaper
 
-<h3>4) Debug (mer logging)</h3>
+<h3>5) Debug (mer logging)</h3>
 python3 frame_art_uploader.py --tvip 192.168.1.20 --bingwallpaper --debug
 </code></pre>
 
@@ -62,6 +70,12 @@ python3 frame_art_uploader.py --tvip 192.168.1.20 --bingwallpaper --debug
       <td>Ja* (enten/eller)</td>
       <td>Bruk et tilfeldig Bing Wallpaper (hentes via HTTP)</td>
       <td><code>--bingwallpaper</code></td>
+    </tr>
+    <tr>
+      <td><code>--unsplash</code></td>
+      <td>Ja* (enten/eller)</td>
+      <td>Bruk et tilfeldig landskapsbilde fra Unsplash (krever UNSPLASH_ACCESS_KEY)</td>
+      <td><code>--unsplash</code></td>
     </tr>
     <tr>
       <td><code>--image &lt;sti&gt;</code></td>


### PR DESCRIPTION
## Summary
- Replace deprecated Unsplash Source URL with official Unsplash API
- Require `UNSPLASH_ACCESS_KEY` and document how to configure it

## Testing
- `python -m py_compile frame_art_uploader.py`
- `python frame_art_uploader.py --help` *(fails: No module named 'samsungtvws')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pillow)*
