### PR TITLE
Fix Google Arts & Culture fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1>Frame Art Uploader 🖼️📺</h1>
-<p>Upload art/photos to <strong>Samsung The Frame</strong> from the command line. Supports either a local image file, a random <em>Bing Wallpaper</em>, or a landscape photo from <em>Unsplash</em> (random or specific). The script automatically crops/resizes to 3840×2160 (4K) before uploading and remembers previously uploaded images in <code>uploaded_files.json</code>.</p>
+<p>Upload art/photos to <strong>Samsung The Frame</strong> from the command line. Supports either a local image file, a random <em>Bing Wallpaper</em>, artwork from <em>Google Arts &amp; Culture</em> (random or by ID/URL), or a landscape photo from <em>Unsplash</em> (random or specific). The script automatically crops/resizes to 3840×2160 (4K) before uploading and remembers previously uploaded images in <code>uploaded_files.json</code>.</p>
 <p>Optionally apply The Frame's built-in <strong>photo filters</strong>, <strong>matte styles</strong>, and <strong>matte colors</strong> when uploading or reusing artwork.</p>
 Based on <a href="https://github.com/xchwarze/samsung-tv-ws-api">github.com/xchwarze</a>'s work<br>
 <hr>
@@ -24,9 +24,11 @@ pip install -r requirements.txt
 <hr>
 
 <h2>▶️ Usage</h2>
-<p>Run the script with <code>--tvip</code> and <em>one</em> of the sources <code>--bingwallpaper</code>, <code>--unsplash [IMAGE_ID]</code>, or <code>--image &lt;path&gt;</code>.</p>
+<p>Run the script with <code>--tvip</code> and <em>one</em> of the sources <code>--bingwallpaper</code>, <code>--unsplash [IMAGE_ID]</code>, <code>--googleart [ART_ID_OR_URL]</code>, or <code>--image &lt;path&gt;</code>.</p>
 
 <p>For <code>--unsplash [IMAGE_ID]</code> you need an <em>Unsplash API access key</em>. Set it in the <code>UNSPLASH_ACCESS_KEY</code> environment variable or directly in <code>frame_art_uploader.py</code>.</p>
+
+<p><code>--googleart [ART_ID_OR_URL]</code> works with the public Google Arts &amp; Culture endpoints and does not require an API key.</p>
 
 <h3>Examples</h3>
 <pre><code><h3>1) Use a random Bing wallpaper on one TV</h3>
@@ -43,13 +45,19 @@ python3 frame_art_uploader.py --tvip 192.168.1.20 --unsplash
 <h3>4) Use a specific Unsplash image by ID</h3>
 python3 frame_art_uploader.py --tvip 192.168.1.20 --unsplash a-body-of-water-surrounded-by-trees-on-a-sunny-day-Pyk2RVJ5fVY
 
-<h3>5) Multiple TVs (comma-separated list)</h3>
+<h3>5) Use a random Google Arts &amp; Culture artwork</h3>
+python3 frame_art_uploader.py --tvip 192.168.1.20 --googleart
+
+<h3>6) Use a specific Google Arts &amp; Culture artwork by ID or URL</h3>
+python3 frame_art_uploader.py --tvip 192.168.1.20 --googleart bgEUEsmHlG6Rbg
+
+<h3>7) Multiple TVs (comma-separated list)</h3>
 python3 frame_art_uploader.py --tvip 192.168.1.20,192.168.1.21 --bingwallpaper
 
-<h3>6) Debug (more logging)</h3>
+<h3>8) Debug (more logging)</h3>
 python3 frame_art_uploader.py --tvip 192.168.1.20 --bingwallpaper --debug
 
-<h3>7) Apply a photo filter and matte</h3>
+<h3>9) Apply a photo filter and matte</h3>
 python3 frame_art_uploader.py --tvip 192.168.1.20 --image /path/to/image.jpg --photo-filter Pastel --matte shadowbox --matte-color polar
 </code></pre>
 
@@ -85,6 +93,12 @@ python3 frame_art_uploader.py --tvip 192.168.1.20 --image /path/to/image.jpg --p
       <td>Yes* (either/or)</td>
       <td>Use an Unsplash photo. Provide IMAGE_ID for a specific photo or omit it for a random landscape (requires UNSPLASH_ACCESS_KEY)</td>
       <td><code>--unsplash</code> or <code>--unsplash a-body-of-water-surrounded-by-trees-on-a-sunny-day-Pyk2RVJ5fVY</code></td>
+    </tr>
+    <tr>
+      <td><code>--googleart [ART_ID_OR_URL]</code></td>
+      <td>Yes* (either/or)</td>
+      <td>Use a Google Arts &amp; Culture artwork. Provide ART_ID_OR_URL for a specific piece or omit it for a random selection.</td>
+      <td><code>--googleart</code> or <code>--googleart bgEUEsmHlG6Rbg</code></td>
     </tr>
     <tr>
       <td><code>--image &lt;path&gt;</code></td>

--- a/frame_art_uploader.py
+++ b/frame_art_uploader.py
@@ -6,8 +6,10 @@ import json
 import argparse
 from io import BytesIO
 import random
-from typing import Tuple, Optional, List, Dict
+import re
+from typing import Tuple, Optional, List, Dict, Any
 from datetime import datetime, timedelta
+from urllib.parse import urljoin
 
 # Eksterne pakker som må være installert:
 #   pip3 install -r requirements.txt
@@ -86,10 +88,24 @@ def build_matte_identifier(matte: str, matte_color: str) -> str:
 # Unsplash API access key (set env var UNSPLASH_ACCESS_KEY or edit here)
 UNSPLASH_ACCESS_KEY: str = os.environ.get("UNSPLASH_ACCESS_KEY", "")
 
+GOOGLE_ARTS_BASE_URL = "https://artsandculture.google.com"
+GOOGLE_ARTS_API_BASE_URL = f"{GOOGLE_ARTS_BASE_URL}/api"
+GOOGLE_ARTS_RANDOM_URL = f"{GOOGLE_ARTS_BASE_URL}/random"
+GOOGLE_ARTS_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Referer": GOOGLE_ARTS_BASE_URL,
+    "X-Requested-With": "XMLHttpRequest",
+}
+
 # -----------------------------
 # Argumenter
 # -----------------------------
-parser = argparse.ArgumentParser(description='Upload images to Samsung Frame TV from Bing Wallpapers, Unsplash, or a local file.')
+parser = argparse.ArgumentParser(description='Upload images to Samsung Frame TV from Bing Wallpapers, Google Arts & Culture, Unsplash, or a local file.')
 parser.add_argument('--debug', action='store_true',
                     help='Enable debug mode to check if TV is reachable (logger mer).')
 parser.add_argument('--tvip', required=True,
@@ -108,6 +124,16 @@ source_group.add_argument(
 )
 source_group.add_argument('--image', type=str,
                           help='Path to a local image that should be uploaded instead of a Bing wallpaper')
+source_group.add_argument(
+    '--googleart',
+    nargs='?',
+    const=True,
+    metavar='ART_ID_OR_URL',
+    help=(
+        'Use art from Google Arts & Culture. Provide ART_ID_OR_URL for a specific '
+        'artwork or leave empty for a random piece.'
+    )
+)
 
 parser.add_argument(
     '--photo-filter',
@@ -272,6 +298,297 @@ def unsplash_get_image(image_id: Optional[str] = None) -> Tuple[Optional[BytesIO
         return None, None, None
 
 # -----------------------------
+# Google Arts & Culture (innebygget)
+# -----------------------------
+def google_arts_normalize_art_id(art_id_or_url: str) -> str:
+    match = re.search(r"/asset/(?:[^/]+/)?([A-Za-z0-9_-]+)", art_id_or_url)
+    if match:
+        return match.group(1)
+    return art_id_or_url
+
+
+def google_arts_normalize_image_url(url: str) -> str:
+    if "googleusercontent" not in url and "gstatic" not in url:
+        return url
+
+    url = re.sub(
+        r"=s\d+(-[a-z0-9-]+)?",
+        lambda m: "=s0" + (m.group(1) or ""),
+        url,
+        count=1,
+        flags=re.IGNORECASE,
+    )
+    url = re.sub(
+        r"=w\d+-h\d+(-[a-z0-9-]+)?",
+        lambda m: "=w0-h0" + (m.group(1) or ""),
+        url,
+        count=1,
+        flags=re.IGNORECASE,
+    )
+
+    if "=s" not in url and "=w" not in url and "=" not in url.split("?")[0]:
+        separator = "" if url.endswith("=") else "="
+        url = f"{url}{separator}s0"
+    return url
+
+
+def google_arts_find_image_url(data: Any) -> Optional[str]:
+    if isinstance(data, str):
+        if data.startswith("http") and (
+            "googleusercontent" in data or "gstatic" in data
+        ):
+            return data
+    elif isinstance(data, dict):
+        for value in data.values():
+            found = google_arts_find_image_url(value)
+            if found:
+                return found
+    elif isinstance(data, list):
+        for value in data:
+            found = google_arts_find_image_url(value)
+            if found:
+                return found
+    return None
+
+
+def google_arts_fetch_asset(art_id: str) -> Optional[Dict[str, Any]]:
+    try:
+        resp = requests.get(
+            f"{GOOGLE_ARTS_API_BASE_URL}/asset",
+            params={"id": art_id, "hl": "en"},
+            headers=GOOGLE_ARTS_HEADERS,
+            timeout=30,
+        )
+        if resp.status_code == 200:
+            return resp.json()
+
+        logging.debug(
+            "Google Arts & Culture API returned HTTP %s for asset '%s'; falling back to HTML page",
+            resp.status_code,
+            art_id,
+        )
+    except requests.RequestException as e:
+        logging.warning(
+            "Failed to fetch Google Arts & Culture asset '%s' via API: %s. Falling back to HTML scrape.",
+            art_id,
+            e,
+        )
+    except ValueError as e:
+        logging.warning(
+            "Failed to parse Google Arts & Culture API response for asset '%s': %s. Falling back to HTML scrape.",
+            art_id,
+            e,
+        )
+
+    return google_arts_fetch_asset_from_page(art_id)
+
+
+def google_arts_extract_image_from_jsonld(data: Any) -> Optional[str]:
+    if isinstance(data, str):
+        if data.startswith("http") and (
+            "googleusercontent" in data or "gstatic" in data
+        ):
+            return data
+        return None
+
+    if isinstance(data, list):
+        for item in data:
+            candidate = google_arts_extract_image_from_jsonld(item)
+            if candidate:
+                return candidate
+        return None
+
+    if isinstance(data, dict):
+        for key in ("contentUrl", "url", "image", "thumbnailUrl", "@graph"):
+            if key not in data:
+                continue
+            candidate = google_arts_extract_image_from_jsonld(data[key])
+            if candidate:
+                return candidate
+
+    return None
+
+
+def google_arts_extract_image_from_html(html: str) -> Optional[str]:
+    script_pattern = re.compile(
+        r"<script[^>]+type=\"application/ld\+json\"[^>]*>(.*?)</script>",
+        re.IGNORECASE | re.DOTALL,
+    )
+
+    for script_content in script_pattern.findall(html):
+        script_content = script_content.strip()
+        if not script_content:
+            continue
+
+        try:
+            data = json.loads(script_content)
+        except json.JSONDecodeError:
+            continue
+
+        candidate = google_arts_extract_image_from_jsonld(data)
+        if candidate:
+            return candidate
+
+    fallback_pattern = re.compile(
+        r"https://lh\d\.googleusercontent\.com/[^\"'<>\s]+",
+        re.IGNORECASE,
+    )
+    candidates = fallback_pattern.findall(html)
+    if not candidates:
+        return None
+
+    def candidate_score(url: str) -> int:
+        size_match = re.search(r"=(?:s|w)(\d+)", url)
+        return int(size_match.group(1)) if size_match else 0
+
+    return max(candidates, key=candidate_score)
+
+
+def google_arts_fetch_asset_from_page(art_id: str) -> Optional[Dict[str, Any]]:
+    candidate_urls = [
+        f"{GOOGLE_ARTS_BASE_URL}/asset/{art_id}",
+        f"{GOOGLE_ARTS_BASE_URL}/asset?id={art_id}",
+    ]
+
+    last_error: Optional[str] = None
+
+    for asset_url in candidate_urls:
+        try:
+            resp = requests.get(
+                asset_url,
+                headers=GOOGLE_ARTS_HEADERS,
+                timeout=30,
+                allow_redirects=True,
+            )
+        except requests.RequestException as e:
+            last_error = str(e)
+            logging.debug(
+                "Failed to load Google Arts & Culture page candidate '%s' for asset '%s': %s",
+                asset_url,
+                art_id,
+                e,
+            )
+            continue
+
+        if resp.status_code >= 400:
+            last_error = f"HTTP {resp.status_code}"
+            logging.debug(
+                "Google Arts & Culture page candidate '%s' for asset '%s' returned HTTP %s",
+                asset_url,
+                art_id,
+                resp.status_code,
+            )
+            continue
+
+        image_url = google_arts_extract_image_from_html(resp.text)
+        if not image_url:
+            last_error = "missing image reference"
+            logging.debug(
+                "Google Arts & Culture page '%s' for asset '%s' did not include an image reference",
+                resp.url,
+                art_id,
+            )
+            continue
+
+        return {
+            "shareUrl": resp.url,
+            "image": image_url,
+        }
+
+    logging.error(
+        "Unable to extract Google Arts & Culture asset '%s' via HTML fallback (%s)",
+        art_id,
+        last_error or "unknown error",
+    )
+    return None
+
+
+def google_arts_get_random_asset_id(max_attempts: int = 5) -> Optional[str]:
+    asset_id_pattern = re.compile(r"/asset/(?:[^/]+/)?([A-Za-z0-9_-]+)")
+
+    for attempt in range(max_attempts):
+        try:
+            resp = requests.get(
+                GOOGLE_ARTS_RANDOM_URL,
+                headers=GOOGLE_ARTS_HEADERS,
+                timeout=30,
+                allow_redirects=True,
+            )
+        except requests.RequestException as e:
+            logging.error(f"Failed to request random Google Arts & Culture artwork: {e}")
+            return None
+
+        if resp.status_code == 404:
+            logging.debug(
+                "Google Arts & Culture random endpoint returned 404 on attempt %d; trying to parse response",
+                attempt + 1,
+            )
+        elif resp.status_code >= 400:
+            logging.warning(
+                "Random Google Arts & Culture request returned HTTP %s on attempt %d",
+                resp.status_code,
+                attempt + 1,
+            )
+            continue
+
+        match = asset_id_pattern.search(resp.url)
+        if match:
+            return match.group(1)
+
+        match = asset_id_pattern.search(resp.text)
+        if match:
+            return match.group(1)
+
+        logging.debug(
+            "Random Google Arts & Culture response did not contain an asset id on attempt %d",
+            attempt + 1,
+        )
+
+    logging.error("Unable to determine a random Google Arts & Culture artwork after multiple attempts")
+    return None
+
+
+def google_arts_get_image(art_id: Optional[str] = None) -> Tuple[Optional[BytesIO], Optional[str], Optional[str]]:
+    normalized_id = google_arts_normalize_art_id(art_id) if art_id else None
+
+    if not normalized_id:
+        normalized_id = google_arts_get_random_asset_id()
+        if not normalized_id:
+            return None, None, None
+        logging.info("Selected random Google Arts & Culture asset id: %s", normalized_id)
+
+    asset_data = google_arts_fetch_asset(normalized_id)
+    if not asset_data:
+        return None, None, None
+
+    share_url = asset_data.get("shareUrl") or asset_data.get("targetUrl") or asset_data.get("url")
+    if share_url:
+        share_url = urljoin(GOOGLE_ARTS_BASE_URL, share_url)
+    else:
+        share_url = f"{GOOGLE_ARTS_BASE_URL}/asset/{normalized_id}"
+
+    image_url = google_arts_find_image_url(asset_data.get("image") or asset_data)
+    if not image_url:
+        logging.error("Google Arts & Culture asset '%s' does not include a downloadable image", normalized_id)
+        return None, None, None
+
+    full_res_url = google_arts_normalize_image_url(image_url)
+
+    try:
+        img_resp = requests.get(full_res_url, headers=GOOGLE_ARTS_HEADERS, timeout=30)
+        img_resp.raise_for_status()
+    except requests.RequestException as e:
+        logging.error(
+            "Failed to download Google Arts & Culture image for asset '%s': %s",
+            normalized_id,
+            e,
+        )
+        return None, None, None
+
+    file_type = img_resp.headers.get('Content-Type', '').split('/')[-1].upper() or 'JPEG'
+    return BytesIO(img_resp.content), file_type, share_url
+
+# -----------------------------
 # Hovedlogikk
 # -----------------------------
 tvip_list: List[str] = args.tvip.split(',') if args.tvip else []
@@ -284,6 +601,7 @@ utils = Utils(args.tvip, uploaded_files)
 
 BING_SOURCE_NAME = "bing_wallpaper"
 UNSPLASH_SOURCE_NAME = "unsplash"
+GOOGLE_ARTS_SOURCE_NAME = "google_arts"
 
 def apply_art_customizations(art_api, tv_ip: str, content_id: str, photo_filter: str, matte_id: str) -> bool:
     if not content_id:
@@ -410,6 +728,17 @@ def get_image_for_tv(tv_ip: Optional[str]):
         image_data, file_type = bing_get_image(image_url)
         if image_data is None:
             return None, None, None, None, None
+    elif args.googleart is not None:
+        google_art_input = None if args.googleart is True else args.googleart
+        image_data, file_type, image_url = google_arts_get_image(google_art_input)
+        if image_data is None or image_url is None:
+            return None, None, None, None, None
+        source_name = GOOGLE_ARTS_SOURCE_NAME
+        logging.info(f'Selected source: {source_name} -> {image_url}')
+
+        remote_filename = utils.get_remote_filename(image_url, source_name, tv_ip)
+        if remote_filename:
+            return None, None, image_url, remote_filename, source_name
     elif args.unsplash is not None:
         unsplash_id = None if args.unsplash is True else args.unsplash
         image_data, file_type, image_url = unsplash_get_image(unsplash_id)
@@ -422,7 +751,7 @@ def get_image_for_tv(tv_ip: Optional[str]):
         if remote_filename:
             return None, None, image_url, remote_filename, source_name
     else:
-        logging.error('No image source specified. Use --bingwallpaper, --unsplash or --image.')
+        logging.error('No image source specified. Use --bingwallpaper, --unsplash, --googleart or --image.')
         return None, None, None, None, None
 
     logging.info('Resizing and cropping the image (3840x2160)...')


### PR DESCRIPTION
## Summary
- add a Google Arts & Culture option to the uploader with HTTP helpers for fetching specific or random artwork
- reuse caching, resizing, and upload flows by integrating the new source into the existing TV processing pipeline
- document the new command-line flag with usage instructions, examples, and argument table updates
- harden the Google Arts & Culture client by tolerating 404 responses from the random endpoint and scraping JSON-LD image data when the API is unavailable
- fix random Google Arts & Culture selection by accepting asset URLs that omit the slug segment so IDs can be extracted reliably

## Testing
- python -m compileall frame_art_uploader.py
- python frame_art_uploader.py --help

------
https://chatgpt.com/codex/tasks/task_e_68c98c9befac8323bf39b7e4c07ac123